### PR TITLE
fix: overflowing hero text

### DIFF
--- a/public/assets/scss/template/_dark-version.scss
+++ b/public/assets/scss/template/_dark-version.scss
@@ -108,6 +108,23 @@
   ul.tab-style--1 li {
     color: var(--active-primary);
   }
+
+  .title.highlight {
+    height: 112px;
+
+    span {
+      display: block;
+    }
+
+    @media (min-width: 768px) {
+      height: auto;
+
+      span {
+        display: inline;
+      }
+    }
+  }
+
   .portfolio-sacousel-inner .slick-dots li button::after,
   .rn-slick-dot .slick-dots li button::after {
     background: #ffffff;
@@ -210,20 +227,10 @@
     .header-area .header-wrapper .mainmenunav ul.mainmenu li a {
       color: #ffffff;
     }
-    .header-area
-      .header-wrapper
-      .mainmenunav
-      ul.mainmenu
-      li.has-droupdown
-      > a::after {
+    .header-area .header-wrapper .mainmenunav ul.mainmenu li.has-droupdown > a::after {
       border-color: #ffffff transparent transparent transparent;
     }
-    .header-area
-      .header-wrapper
-      .mainmenunav
-      ul.mainmenu
-      li.has-droupdown
-      > a.open::after {
+    .header-area .header-wrapper .mainmenunav ul.mainmenu li.has-droupdown > a.open::after {
       border-color: transparent transparent var(--color-primary) transparent;
     }
   }
@@ -246,20 +253,10 @@
     .header-area .header-wrapper .mainmenunav ul.mainmenu li a {
       color: #ffffff;
     }
-    .header-area
-      .header-wrapper
-      .mainmenunav
-      ul.mainmenu
-      li.has-droupdown
-      > a::after {
+    .header-area .header-wrapper .mainmenunav ul.mainmenu li.has-droupdown > a::after {
       border-color: #ffffff transparent transparent transparent;
     }
-    .header-area
-      .header-wrapper
-      .mainmenunav
-      ul.mainmenu
-      li.has-droupdown
-      > a.open::after {
+    .header-area .header-wrapper .mainmenunav ul.mainmenu li.has-droupdown > a.open::after {
       border-color: transparent transparent var(--color-primary) transparent;
     }
   }
@@ -270,10 +267,7 @@
   .accodion-style--1 .accordion__item .accordion__heading .accordion__button {
     color: #fff;
   }
-  .accodion-style--1
-    .accordion__item
-    .accordion__heading
-    .accordion__button::after {
+  .accodion-style--1 .accordion__item .accordion__heading .accordion__button::after {
     background: #353434;
   }
 
@@ -288,11 +282,6 @@
   color: #000;
 }
 
-.active-dark
-  .header-area.header--fixed.default-color.sticky
-  .mainmenunav
-  ul.mainmenu
-  > li
-  > a {
+.active-dark .header-area.header--fixed.default-color.sticky .mainmenunav ul.mainmenu > li > a {
   color: #ffff;
 }

--- a/src/dark/PortfolioLanding.jsx
+++ b/src/dark/PortfolioLanding.jsx
@@ -41,15 +41,22 @@ const PortfolioLanding = () => {
                                     <div className="col-lg-12">
                                         <div className={`inner ${value.textPosition}`}>
                                             {value.category ? <span className="hero-subheadline">{value.category}</span> : ''}
-                                            <h1 className="title hero-headline">Lloyd Consulting Co <br />
-                                                <TextLoop>
-                                                    <span> Advocate.</span>
-                                                    <span> Counsellor.</span>
-                                                    <span> Humane.</span>
-                                                    <span> Lived Experience.</span>
-                                                    <span> Diversity Consultant.</span>
-                                                </TextLoop>{" "}
+                                            <h1 className="title hero-headline">
+                                                Lloyd Consulting Co
                                             </h1>
+                                            <TextLoop>
+                                                <h1 className="title highlight"><span>Advocate.</span></h1>
+                                                <h1 className="title highlight"><span>Counsellor.</span></h1>
+                                                <h1 className="title highlight"><span>Humane.</span></h1>
+                                                <h1 className="title highlight">
+                                                    <span>Lived </span>
+                                                    <span>Experience.</span>
+                                                </h1>
+                                                <h1 className="title highlight">
+                                                    <span>Diversity </span>
+                                                    <span>Consultant.</span>
+                                                </h1>
+                                            </TextLoop>
                                             <h2 className="hero-headline">Business Done Differently</h2>
                                             {value.description ? <p className="description">{value.description}</p> : ''}
                                             {value.buttonText ? <div className="slide-btn mt--30"><a className="btn-default btn-border btn-opacity" href={`${value.buttonLink}`}>{value.buttonText}</a></div> : ''}


### PR DESCRIPTION
## Rationale

Fixes the hero headline text overflowing on mobile viewports.

P.S. This is such a hacky fix that I am ashamed.

## Advice for Reviewers & Testing Notes

View Vercel Deploy and change the viewport to a mobile resolution.

## Screenshots:

### Before

![Screen Shot 2023-01-14 at 17 04 10](https://user-images.githubusercontent.com/8443215/212458430-312f579f-acd1-4f36-931d-dae32d920c36.png)

### After

![Screen Shot 2023-01-14 at 17 03 36](https://user-images.githubusercontent.com/8443215/212458431-b4c7eeb6-67e0-4396-a294-598bda1eec90.png)

![Screen Shot 2023-01-14 at 17 03 28](https://user-images.githubusercontent.com/8443215/212458432-d1bfaed4-5a4c-47e6-87b4-1a3f7981074b.png)


## Task Name

- #51 

## Linting Checklist
- [X] No commented code
- [X] Code Formatted nicely (Prettier)
- [X] PR your own code before you assign reviewers